### PR TITLE
add sphinx to project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@
 **/.vscode
 neurosnap.egg-info
 test_files/
+
+# sphinx
+docs/build/
+# docs/source/
+# !docs/source/conf.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+.PHONY: docs
+
+docs:
+	./venv/bin/sphinx-apidoc -o ./docs/source ./src/neurosnap
+	cd docs && make html

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ source venv/bin/activate
 pip install --editable .[dev]
 ```
 
+# Building documentation
+To build documentation, enter your virtual environment and run `make docs` from
+the root of the repository.
+
 # Installation
 ```sh
 pip install -U --no-cache-dir git+https://github.com/NeurosnapInc/neurosnap.git

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,0 +1,7 @@
+api module
+==========
+
+.. automodule:: api
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/chemicals.rst
+++ b/docs/source/chemicals.rst
@@ -1,0 +1,7 @@
+chemicals module
+================
+
+.. automodule:: chemicals
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,35 @@
+import os, sys
+
+sys.path.insert(0, os.path.abspath("../src/neurosnap/"))
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'neurosnap'
+copyright = '2024, Keaun Amani'
+author = 'Keaun Amani'
+release = '0.0.62'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+  'sphinx.ext.autodoc',
+  'sphinx.ext.napoleon',
+]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/conformers.rst
+++ b/docs/source/conformers.rst
@@ -1,0 +1,7 @@
+conformers module
+=================
+
+.. automodule:: conformers
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,24 @@
+.. neurosnap documentation master file, created by
+   sphinx-quickstart on Fri Oct 25 17:18:01 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+neurosnap documentation
+=======================
+
+Add your content using ``reStructuredText`` syntax. See the
+`reStructuredText <https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html>`_
+documentation for details.
+
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/log.rst
+++ b/docs/source/log.rst
@@ -1,0 +1,7 @@
+log module
+==========
+
+.. automodule:: log
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,12 @@
+neurosnap
+=========
+
+.. toctree::
+   :maxdepth: 4
+
+   api
+   chemicals
+   conformers
+   log
+   msa
+   protein

--- a/docs/source/msa.rst
+++ b/docs/source/msa.rst
@@ -1,0 +1,7 @@
+msa module
+==========
+
+.. automodule:: msa
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/neurosnap.rst
+++ b/docs/source/neurosnap.rst
@@ -1,0 +1,61 @@
+neurosnap package
+=================
+
+Submodules
+----------
+
+neurosnap.api module
+--------------------
+
+.. automodule:: neurosnap.api
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+neurosnap.chemicals module
+--------------------------
+
+.. automodule:: neurosnap.chemicals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+neurosnap.conformers module
+---------------------------
+
+.. automodule:: neurosnap.conformers
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+neurosnap.log module
+--------------------
+
+.. automodule:: neurosnap.log
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+neurosnap.msa module
+--------------------
+
+.. automodule:: neurosnap.msa
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+neurosnap.protein module
+------------------------
+
+.. automodule:: neurosnap.protein
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: neurosnap
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/protein.rst
+++ b/docs/source/protein.rst
@@ -1,0 +1,7 @@
+protein module
+==============
+
+.. automodule:: protein
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["ruff==0.7.0"]
+dev = [
+  "ruff==0.7.0",
+  "sphinx==8.1.3",
+]
 
 [project.urls]
 Homepage = "https://github.com/NeurosnapInc/neurosnap"


### PR DESCRIPTION
- Add `__init__.py`
	- this is good to have anyways because all directories are packages in python, but putting in the init.py makes it a namespace package
	- this helps with the discovery of docstrings automatically using the autodoc extension in sphinx
	- more details about this
		- https://stackoverflow.com/questions/448271/what-is-init-py-for
		- https://dev.to/methane/don-t-omit-init-py-3hga
	
- this is just the barebones but I want to get it into the repo so people can experiment with it and any issues can be surfaced now
	- also don't want to have a super mega large PR doing all of sphinx at once since its harder to review